### PR TITLE
Bio::DB::HTS requirements added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ You can use the `--checkout` command. This will perform a fetch from the default
 
 The `git-ensembl` command can be supplemented with user and global configuration allowing you to define new groups and modules or override existing groups and modules with new definitions. That configuration must be called `git-ensembl.cfg` and can be located in `$HOME` or `~ensembl`. User based configuration will always win. You can also specify a config on the command line.
 
+#### ensembl-io and Bio::DB::HTS
+
+Tabix and BAM/CRAM file access using ensembl-io requires the Bio::DB::HTS module
+to be installed. For details on how to obtain and install this please
+see [https://github.com/Ensembl/Bio-HTS](https://github.com/Ensembl/Bio-HTS).
+
+Alternatively, Bio::DB::HTS can be installed from CPAN.
+
+
 ### git-mgw
 
 ```


### PR DESCRIPTION
Letting the users know ensembl-io requires Bio::DB::HTS 